### PR TITLE
feat: package django as an exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@
 *.pyc
 /app/uploads/*
 !/app/uploads/.gitkeep
+build/
+dist/
+/.DS_Store
 
 

--- a/hook-urllib3.py
+++ b/hook-urllib3.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('urllib3')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 absl-py==2.1.0
 alabaster==0.7.16
 albumentations==1.3.1
+altgraph==0.17.4
 antlr4-python3-runtime==4.9.3
 anyio==4.4.0
 arabic-reshaper==3.0.0
@@ -9,7 +10,7 @@ asn1crypto==1.5.1
 attrs==23.2.0
 Babel==2.14.0
 boto3==1.34.61
-botocore==1.34.61
+botocore==1.35.20
 build==1.1.1
 certifi==2024.2.2
 cffi==1.16.0
@@ -59,6 +60,7 @@ kiwisolver==1.4.5
 lapx==0.5.5
 lazy_loader==0.3
 lxml==5.1.0
+macholib==1.16.3
 Markdown==3.5.2
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
@@ -91,6 +93,8 @@ pyDeprecate==0.3.2
 Pygments==2.17.2
 pyHanko==0.23.0
 pyhanko-certvalidator==0.26.3
+pyinstaller==6.10.0
+pyinstaller-hooks-contrib==2024.8
 pyparsing==2.4.5
 pypdf==4.1.0
 pypng==0.20220715.0
@@ -150,7 +154,7 @@ tzdata==2024.1
 tzlocal==5.2
 ultralytics==8.0.209
 uritools==4.0.2
-urllib3==1.26.18
+urllib3==2.2.3
 uvicorn==0.30.6
 uvloop==0.20.0
 watchfiles==0.24.0

--- a/run_local.py
+++ b/run_local.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import socket
+from django.core.management import execute_from_command_line
+from django.conf import settings
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
+
+if __name__ == '__main__':
+    # Check if we are in a PyInstaller-built executable
+    if getattr(sys, 'frozen', False):
+        # Disable Django's autoreload if running inside PyInstaller executable
+        settings.DEBUG = False
+        os.environ['RUN_MAIN'] = 'true'  # Prevent Django from trying to restart
+
+    # Find an available port
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))
+        port = s.getsockname()[1]
+
+    # Print the port number so Electron can read it
+    print(port)
+    sys.stdout.flush()
+
+    # Start the Django server on the available port, without autoreload
+    execute_from_command_line([sys.argv[0], 'runserver', f'127.0.0.1:{port}', '--noreload'])

--- a/run_local.spec
+++ b/run_local.spec
@@ -1,0 +1,63 @@
+# -*- mode: python ; coding: utf-8 -*-
+import os
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+# Automatically collect all non-Python data files from ultralytics, super_gradients, urllib3, and botocore
+ultralytics_datas = collect_data_files('ultralytics')
+super_gradients_datas = collect_data_files('super_gradients')
+urllib3_datas = collect_data_files('urllib3')
+botocore_datas = collect_data_files('botocore')
+
+# Combine the data from all packages
+datas = ultralytics_datas + super_gradients_datas + urllib3_datas + botocore_datas
+
+# Collect all hidden submodules from super_gradients and botocore, including urllib3 and ssl_
+hiddenimports = collect_submodules('super_gradients') + collect_submodules('botocore') + [
+    'matplotlib.backends.backend_agg',
+    'ssl',  # Ensure ssl is bundled
+    'urllib3.util.ssl_',  # Ensure urllib3 SSL utility is bundled
+    'pycocotools',
+]
+
+# Add custom hook for urllib3 (optional)
+hookspath=['.']  # Add the directory where your custom hook for urllib3 is located
+
+# Set your project base directory (dynamically determined path)
+project_dir = os.path.abspath('.')
+
+a = Analysis(
+    ['run_local.py'],
+    pathex=[project_dir, os.path.join(project_dir, 'backend')],
+    binaries=[],
+    datas=datas,  # Include the collected data files
+    hiddenimports=hiddenimports,  # Include hidden imports
+    hookspath=hookspath,  # Include hooks path for custom hooks
+    runtime_hooks=[],
+    excludes=['super_gradients.modules.quantization'],  # Exclude quantization module if needed
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='run_local',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+


### PR DESCRIPTION
Facing issues with PyInstaller as its not able to package the dependencies properly, we are getting runtime errors which I had to fix by adding the required files manually in .spec file which is not efficient solution IMO, we might have to pursue Docker solution if this doesn't work. I'm still facing issues with imports
```bash
 File "botocore/httpsession.py", line 22, in <module>
ImportError: cannot import name 'ssl' from 'urllib3.util.ssl_' (/var/folders/7q/70gjb_3108g92fn1by5tzjkw0000gn/T/_MEIXVlI8Q/urllib3/util/ssl_.pyc)
[PYI-76099:ERROR] Failed to execute script 'run_local' due to unhandled exception!
``` 
will have a look at it tomorrow